### PR TITLE
fix: buffer.toArrayBuffer is not a function

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -136,7 +136,7 @@ Socket.prototype._write = function(id, chunk, encoding, callback) {
       chunk = chunk.toString(encoding);
     } else if (!global.Buffer) {
       // socket.io can't handle Buffer when using browserify.
-      chunk = chunk.toArrayBuffer();
+      chunk = chunk.buffer;
     }
   }
   this.sio.emit(exports.event + '-write', id, chunk, encoding, callback);


### PR DESCRIPTION
browserify's implementation of Buffer has aligned with node.js', in which there is no `.toArrayBuffer()` in favor of `.buffer`.

This PR fixes a fatal error which is occuring when using socket.io-stream in the browser (under browserify) when using Browserify v13 which includes https://github.com/substack/node-browserify/pull/1476 and was released Jan 9.

Should we aim to support both by detecting which of `.buffer` or `.toArrayBuffer()` exists (I'm not sure if you could always do `.buffer` in addition to `.toArrayBuffer()` before browserify v13).