### PR TITLE
Fix: do not crash when IOStream._read() is called before socket is set

### DIFF
--- a/lib/iostream.js
+++ b/lib/iostream.js
@@ -57,6 +57,7 @@ IOStream.prototype.destroy = function() {
     return;
   }
 
+
   this.readable = this.writable = false;
 
   if (this.socket) {
@@ -77,7 +78,7 @@ IOStream.prototype._read = function(size) {
   var push;
 
   // We can not read from the socket if it's destroyed obviously ...
-  if (this.destroyed) return;
+  if (this.destroyed || this.socket === null) return;
 
   if (this.pushBuffer.length) {
     // flush buffer and end if it exists.

--- a/test/connection.js
+++ b/test/connection.js
@@ -7,6 +7,14 @@ var client = support.client;
 describe('socket.io-stream', function() {
   this.timeout(70000);
 
+  it('should not crash when _read() is called before the socket is set', function(done) {
+    var stream = ss.createStream();
+    stream.read(0);
+
+    done();
+  });
+
+  ////
   it('should send/receive a file', function(done) {
     var sums = [];
     var socket = client();


### PR DESCRIPTION
I found out that 'sometimes' _read() was called on IOStream before the socket wrapper was able to configure the socket.

Stacktrace:

```javascript
/var/www/..../node_modules/socket.io-stream/lib/iostream.js:97
this.socket._read(this.id, size);
            ^

TypeError: Cannot read property '_read' of null
   at IOStream._read (/var/www/...../node_modules/socket.io-stream/lib/iostream.js:97:14)
   at IOStream.Readable.read (_stream_readable.js:328:10)
   at resume_ (_stream_readable.js:718:12)
   at nextTickCallbackWith2Args (node.js:455:9)
   at process._tickCallback (node.js:369:17)
```

I have implemented a test case where the stream is asked to read before the socket was set and now it doesn't crash anymore.

I do not think this is **the** fix and I am convinced that this problem is caused by something else but I do not know the library well enough to figure that out shortly.

Is it possible that this has todo because of promises being resolved within my listener on the wrapped socket when an upload is done?

My implementation (pseudo code):

```javascript
var streamSocket = ss(socket);
streamSocket.on('upload', function() {
    var streams = {}, data = null;
    ... some code to populate streams and data based on arguments ...

    ... start loop through collected streams ...
	var writeStream = fs.createWriteStream(somepath);
	collectedStream.pipe(writeStream);
    ... end loop through collected streams ...

});
```

The inputStream is listening for the 'end' event and resolves the promise created for that stream
Promise.all(streamPromises).then(....); handles some stuff and responds by emitting some event but 'sometimes' it fails by triggering the _read() on the IOStream as mentioned above.

If I missed something or made a mistake please let me know.