### PR TITLE
fix: buffer.toArrayBuffer not a function 

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -136,7 +136,11 @@ Socket.prototype._write = function(id, chunk, encoding, callback) {
       chunk = chunk.toString(encoding);
     } else if (!global.Buffer) {
       // socket.io can't handle Buffer when using browserify.
-      chunk = chunk.toArrayBuffer();
+      if (chunk.toArrayBuffer) {
+        chunk = chunk.toArrayBuffer();
+      } else {
+        chunk = chunk.buffer;
+      }
     }
   }
   this.sio.emit(exports.event + '-write', id, chunk, encoding, callback);


### PR DESCRIPTION
Related to: https://github.com/nkzawa/socket.io-stream/pull/74

This is a different pull request to solve the problem where `.toArrayBuffer` fails on newer versions of Browserify. The pull request on the thread I linked failed tests, I imagine because it didn't test if `.toArrayBuffer` was a function before attempting to use `chunk.buffer`. 

Sorry if there was a way to submit this on that thread, I'm pretty unfamiliar with contributing to open source projects. 