### PR TITLE
Update debug version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "component-bind": "~1.0.0",
-    "debug": "~2.2.0"
+    "debug": "^2.6.9"
   },
   "devDependencies": {
     "blob": "0.0.4",


### PR DESCRIPTION
The used `debug` version has a DDoS vulnerability ([more info](https://npmjs.com/advisories/534)) and is blocking some of our packages from being published to npm (vulnerability checks before pushing to production)

This should be a simple package update with no breaking changes